### PR TITLE
Wiim mini fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 wiimplay
+scan/scan
 \#*
 *~
 *.sublime-project

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ SRC=main.go \
     wiimdev/fake.go \
     upnp/schema.go \
     upnp/wiim.go \
+    upnp/soap/soap.go \
     dcache/dcache.go \
     mpris/server.go \
     ui/controller.go \

--- a/upnp/soap/soap.go
+++ b/upnp/soap/soap.go
@@ -1,0 +1,57 @@
+package soap
+
+import (
+    "github.com/huin/goupnp/soap"
+)
+
+func MarshalUi2(v uint16) (string, error) {
+    return soap.MarshalUi2(v)
+}
+
+func UnmarshalUi2(s string) (uint16, error) {
+    if s == "" {
+        return 0, nil
+    }
+    return soap.UnmarshalUi2(s)
+}
+
+func MarshalUi4(v uint32) (string, error) {
+    return soap.MarshalUi4(v)
+}
+
+func UnmarshalUi4(s string) (uint32, error) {
+    if s == "" {
+        return 0, nil
+    }
+    return soap.UnmarshalUi4(s)
+}
+
+func MarshalI4(v int32) (string, error) {
+    return soap.MarshalI4(v)
+}
+
+func UnmarshalI4(s string) (int32, error) {
+    if s == "" {
+        return 0, nil
+    }
+    return soap.UnmarshalI4(s)
+}
+
+func MarshalString(v string) (string, error) {
+    return soap.MarshalString(v)
+}
+
+func UnmarshalString(v string) (string, error) {
+    return soap.UnmarshalString(v)
+}
+
+func MarshalBoolean(v bool) (string, error) {
+    return soap.MarshalBoolean(v)
+}
+
+func UnmarshalBoolean(s string) (bool, error) {
+    if s == "" {
+        return false, nil
+    }
+    return soap.UnmarshalBoolean(s)
+}

--- a/upnp/wiim.go
+++ b/upnp/wiim.go
@@ -16,7 +16,7 @@ import (
     "time"
 
     "github.com/huin/goupnp"
-    "github.com/huin/goupnp/soap"
+    "github.com/shumatech/wiimplay/upnp/soap"
 )
 
 // Hack to avoid Go complaining if time isn't used.
@@ -313,9 +313,7 @@ func (client *AVTransport1) GetInfoExCtx(
     if CurrentVolume, err = soap.UnmarshalUi4(response.CurrentVolume); err != nil {
         return
     }
-    if response.CurrentMute == "" {
-        CurrentMute = 0
-    } else if CurrentMute, err = soap.UnmarshalUi4(response.CurrentMute); err != nil {
+    if CurrentMute, err = soap.UnmarshalUi4(response.CurrentMute); err != nil {
         return
     }
     if CurrentChannel, err = soap.UnmarshalUi4(response.CurrentChannel); err != nil {

--- a/upnp/wiim.go
+++ b/upnp/wiim.go
@@ -313,7 +313,9 @@ func (client *AVTransport1) GetInfoExCtx(
     if CurrentVolume, err = soap.UnmarshalUi4(response.CurrentVolume); err != nil {
         return
     }
-    if CurrentMute, err = soap.UnmarshalUi4(response.CurrentMute); err != nil {
+    if response.CurrentMute == "" {
+        CurrentMute = 0
+    } else if CurrentMute, err = soap.UnmarshalUi4(response.CurrentMute); err != nil {
         return
     }
     if CurrentChannel, err = soap.UnmarshalUi4(response.CurrentChannel); err != nil {


### PR DESCRIPTION
Use default values for fields not returned in the UPNP responses instead of generating an error.